### PR TITLE
Fix launch argument default_bt_xml_filename

### DIFF
--- a/launch/nav2_bringup_launch.py
+++ b/launch/nav2_bringup_launch.py
@@ -37,7 +37,7 @@ def generate_launch_description():
     map_yaml_file = LaunchConfiguration('map')
     use_sim_time = LaunchConfiguration('use_sim_time')
     params_file = LaunchConfiguration('params_file')
-    bt_xml_file = LaunchConfiguration('bt_xml_file')
+    default_bt_xml_filename = LaunchConfiguration('default_bt_xml_filename')
     autostart = LaunchConfiguration('autostart')
 
     stdout_linebuf_envvar = SetEnvironmentVariable(
@@ -68,10 +68,10 @@ def generate_launch_description():
         description='Full path to the ROS2 parameters file to use for all launched nodes')
 
     declare_bt_xml_cmd = DeclareLaunchArgument(
-        'bt_xml_file',
+        'default_bt_xml_filename',
         default_value=os.path.join(
             get_package_share_directory('nav2_bt_navigator'),
-            'behavior_trees', 'navigate_w_replanning_and_recovery.xml'),
+            'behavior_trees', 'navigate_w_replanning_distance.xml'),
         description='Full path to the behavior tree xml file to use')
 
     declare_autostart_cmd = DeclareLaunchArgument(
@@ -100,7 +100,7 @@ def generate_launch_description():
                               'use_sim_time': use_sim_time,
                               'autostart': autostart,
                               'params_file': params_file,
-                              'bt_xml_file': bt_xml_file,
+                              'default_bt_xml_filename': default_bt_xml_filename,
                               'use_lifecycle_mgr': 'false',
                               'map_subscribe_transient_local': 'true'}.items()),
     ])

--- a/launch/nav2_navigation_launch.py
+++ b/launch/nav2_navigation_launch.py
@@ -32,7 +32,7 @@ def generate_launch_description():
     use_sim_time = LaunchConfiguration('use_sim_time')
     autostart = LaunchConfiguration('autostart')
     params_file = LaunchConfiguration('params_file')
-    bt_xml_file = LaunchConfiguration('bt_xml_file')
+    default_bt_xml_filename = LaunchConfiguration('default_bt_xml_filename')
     map_subscribe_transient_local = LaunchConfiguration('map_subscribe_transient_local')
 
     lifecycle_nodes = ['controller_server',
@@ -53,7 +53,7 @@ def generate_launch_description():
     # Create our own temporary YAML files that include substitutions
     param_substitutions = {
         'use_sim_time': use_sim_time,
-        'bt_xml_filename': bt_xml_file,
+        'default_bt_xml_filename': default_bt_xml_filename,
         'autostart': autostart,
         'map_subscribe_transient_local': map_subscribe_transient_local}
 
@@ -83,10 +83,10 @@ def generate_launch_description():
             description='Full path to the ROS2 parameters file to use'),
 
         DeclareLaunchArgument(
-            'bt_xml_file',
+            'default_bt_xml_filename',
             default_value=os.path.join(
                 get_package_share_directory('nav2_bt_navigator'),
-                'behavior_trees', 'navigate_w_replanning_and_recovery.xml'),
+                'behavior_trees', 'navigate_w_replanning_distance.xml'),
             description='Full path to the behavior tree xml file to use'),
 
         DeclareLaunchArgument(

--- a/launch/navigation_simulation.launch.py
+++ b/launch/navigation_simulation.launch.py
@@ -41,7 +41,7 @@ def generate_launch_description():
     map_yaml_file = LaunchConfiguration('map')
     use_sim_time = LaunchConfiguration('use_sim_time')
     params_file = LaunchConfiguration('params_file')
-    bt_xml_file = LaunchConfiguration('bt_xml_file')
+    default_bt_xml_filename = LaunchConfiguration('default_bt_xml_filename')
     autostart = LaunchConfiguration('autostart')
 
     # Launch configuration variables specific to simulation
@@ -73,15 +73,15 @@ def generate_launch_description():
         description='Full path to the ROS2 parameters file to use for all launchde nodes')
 
     declare_bt_xml_cmd = DeclareLaunchArgument(
-        'bt_xml_file',
+        'default_bt_xml_filename',
         default_value=os.path.join(
             get_package_share_directory('nav2_bt_navigator'),
-            'behavior_trees', 'navigate_w_replanning.xml'),
+            'behavior_trees', 'navigate_w_replanning_distance.xml'),
         description='Full path to the behavior tree xml file to use')
 
     declare_autostart_cmd = DeclareLaunchArgument(
         'autostart',
-        default_value='false',
+        default_value='true',
         description='Automatically startup the nav2 stack')
 
     declare_rviz_config_file_cmd = DeclareLaunchArgument(
@@ -130,7 +130,7 @@ def generate_launch_description():
                           'map': map_yaml_file,
                           'use_sim_time': use_sim_time,
                           'params_file': params_file,
-                          'bt_xml_file': bt_xml_file,
+                          'default_bt_xml_filename': default_bt_xml_filename,
                           'autostart': autostart}.items())
 
     start_rviz_cmd = Node(


### PR DESCRIPTION
- Path is now being created but marta is not autonomously moving when running
navigation_simulation.launch.py

- To make rover move there is the need to provide a locomotion mode to marta rover, otherwise it would be waiting for it to be set indefinitely. This can be done either by using the gamepad or gamepad emulation, running the following command:  `ros2 run gamepad_emulation gamepad_emulation_node --ros-args -r joy:=gamepad `

- Once the emulation launches hold `1`  to select the locomotion mode. You will see in the navigation_simulation.launch.py terminal that the locomotion mode has changed from stop_mode to simple_rover_locomotion_mode. 

- You can now set a path using Navigation2Goal.
- Further work will be done to automatically set the locomotion mode on startup.